### PR TITLE
INT8 static KV-cache

### DIFF
--- a/examples/quantization_kv_cache/llama3_int8_static.py
+++ b/examples/quantization_kv_cache/llama3_int8_static.py
@@ -54,6 +54,6 @@ oneshot(
 )
 
 # Save quantized model: Llama-3.1-8B-Instruct-FP8-KV
-SAVE_DIR = "/mlf8-shared/aleksanderk/Llama-3.1-8B-Instruct-INT8-KV"
+SAVE_DIR = "/mlf8-shared/aleksanderk/Llama-3.1-8B-Instruct-INT8-KV-2_HEADS"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)

--- a/examples/quantization_kv_cache/llama3_int8_static.py
+++ b/examples/quantization_kv_cache/llama3_int8_static.py
@@ -1,0 +1,59 @@
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from llmcompressor.transformers import oneshot
+
+# Select model and load it
+MODEL_ID = "/mlf8-shared/hf_cache/hub/Llama-3.1-8B-Instruct"
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID, device_map="auto", torch_dtype="auto")
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+# Select calibration dataset
+DATASET_ID = "HuggingFaceH4/ultrachat_200k"
+DATASET_SPLIT = "train_sft"
+
+# Configure calibration parameters
+NUM_CALIBRATION_SAMPLES = 512  # 512 samples is a good starting point
+MAX_SEQUENCE_LENGTH = 2048
+
+# Load and preprocess dataset
+ds = load_dataset(DATASET_ID, split=DATASET_SPLIT)
+ds = ds.shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))
+
+def process_and_tokenize(example):
+    text = tokenizer.apply_chat_template(example["messages"], tokenize=False)
+    return tokenizer(
+        text,
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+ds = ds.map(process_and_tokenize, remove_columns=ds.column_names)
+
+# Configure quantization settings
+recipe = """
+quant_stage:
+    quant_modifiers:
+        QuantizationModifier:
+            kv_cache_scheme:
+                num_bits: 8
+                type: int
+                strategy: tensor
+                dynamic: false
+                symmetric: true
+"""
+
+# Apply quantization
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+# Save quantized model: Llama-3.1-8B-Instruct-FP8-KV
+SAVE_DIR = "/mlf8-shared/aleksanderk/Llama-3.1-8B-Instruct-INT8-KV"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/src/llmcompressor/modifiers/quantization/calibration.py
+++ b/src/llmcompressor/modifiers/quantization/calibration.py
@@ -189,6 +189,14 @@ def calibrate_kv_cache_output_hook(module: Module, _args: Any, _output: torch.Te
     kv_cache = getattr(module, "kv_cache")
     k_scale = kv_cache.k_scales[module.layer_idx]
     v_scale = kv_cache.v_scales[module.layer_idx]
+    param = getattr(module, KVCacheScaleType.KEY.value)
+    if param.data.shape != k_scale.shape:
+        param.data = torch.empty_like(k_scale)
+        setattr(module, KVCacheScaleType.KEY.value, param)
+    param = getattr(module, KVCacheScaleType.VALUE.value)
+    if param.data.shape != v_scale.shape:
+        param.data = torch.empty_like(v_scale)
+        setattr(module, KVCacheScaleType.VALUE.value, param)
     update_parameter_data(module, k_scale, KVCacheScaleType.KEY.value)
     update_parameter_data(module, v_scale, KVCacheScaleType.VALUE.value)
 

--- a/src/llmcompressor/observers/min_max.py
+++ b/src/llmcompressor/observers/min_max.py
@@ -4,6 +4,8 @@ import torch
 from compressed_tensors.quantization.quant_args import QuantizationArgs
 from compressed_tensors.quantization.utils import calculate_qparams
 from compressed_tensors.utils import deprecated
+from compressed_tensors.quantization import QuantizationStrategy
+from copy import copy
 
 from llmcompressor.observers.base import Observer
 
@@ -52,7 +54,22 @@ class MinMaxObserver(Observer):
         tensor_id = tensor_id or "default"
 
         if not reduce_dims:
-            min_val, max_val = torch.aminmax(observed)
+            seq_len = observed.shape[2]
+            num_heads = observed.shape[1]
+            GROUP_SIZE = 8
+            num_groups = observed.shape[3] // GROUP_SIZE
+            reshaped = observed.moveaxis(2, 3).contiguous()
+            reshaped = reshaped.view(num_heads, num_groups, -1)
+            #print(f"reshaped: {reshaped.shape}")
+            #print(f"quantization_args: {self.quantization_args}")
+            #quantization_args = copy(self.quantization_args)
+            #quantization_args.strategy = QuantizationStrategy.CHANNEL
+
+            # TODO: quantize part from few heads together (not from one head)
+            min_val = torch.amin(reshaped, dim=-1, keepdims=False).unsqueeze(0).unsqueeze(2)
+            min_val = torch.repeat_interleave(min_val, GROUP_SIZE, dim=3)
+            max_val = torch.amax(reshaped, dim=-1, keepdims=False).unsqueeze(0).unsqueeze(2)
+            max_val = torch.repeat_interleave(max_val, GROUP_SIZE, dim=3)
         else:
             min_val = torch.amin(observed, dim=reduce_dims, keepdims=True)
             max_val = torch.amax(observed, dim=reduce_dims, keepdims=True)

--- a/src/llmcompressor/observers/min_max.py
+++ b/src/llmcompressor/observers/min_max.py
@@ -57,20 +57,39 @@ class MinMaxObserver(Observer):
         if not reduce_dims:
             seq_len = observed.shape[2]
             num_heads = observed.shape[1]
-            GROUP_SIZE = 8
-            num_groups = observed.shape[3] // GROUP_SIZE
+            feature_dim = observed.shape[3]
+            GROUP_SIZE = 4  # 4 elements per head in each group
+            COLLOCATED_HEADS = 2
+            
+            # Ensure num_heads is even for pairing
+            assert num_heads % COLLOCATED_HEADS == 0, "Number of heads must be even for pairing"
+            assert feature_dim % GROUP_SIZE == 0, "Feature dimension must be divisible by GROUP_SIZE"
+            
+            num_head_pairs = num_heads // COLLOCATED_HEADS
+            num_groups = feature_dim // GROUP_SIZE
+            
+            # Move seq_len to last dimension: (batch, num_heads, feature_dim, seq_len)
             reshaped = observed.moveaxis(2, 3).contiguous()
-            reshaped = reshaped.view(num_heads, num_groups, -1)
-            #print(f"reshaped: {reshaped.shape}")
-            #print(f"quantization_args: {self.quantization_args}")
-            #quantization_args = copy(self.quantization_args)
-            #quantization_args.strategy = QuantizationStrategy.CHANNEL
-
-            # TODO: quantize part from few heads together (not from one head)
-            min_val = torch.amin(reshaped, dim=-1, keepdims=False).unsqueeze(0).unsqueeze(2) #688 651 924
-            min_val = torch.repeat_interleave(min_val, GROUP_SIZE, dim=3)
-            max_val = torch.amax(reshaped, dim=-1, keepdims=False).unsqueeze(0).unsqueeze(2)
-            max_val = torch.repeat_interleave(max_val, GROUP_SIZE, dim=3)
+            
+            # Reshape to pair heads and group features: (batch, num_head_pairs, 2, num_groups, GROUP_SIZE, seq_len)
+            reshaped = reshaped.view(observed.shape[0], num_head_pairs, COLLOCATED_HEADS, num_groups, GROUP_SIZE, seq_len)
+            reshaped = reshaped.moveaxis(2, 3).contiguous()
+            
+            # Reshape to compute min/max across 8 elements (2 heads * GROUP_SIZE elements each)
+            # Final shape: (num_head_pairs, num_groups, batch * 2 * GROUP_SIZE * seq_len)
+            reshaped = reshaped.view(num_head_pairs, num_groups, -1)
+            
+            min_val = torch.amin(reshaped, dim=-1, keepdims=False)  # (num_head_pairs, num_groups)
+            max_val = torch.amax(reshaped, dim=-1, keepdims=False)  # (num_head_pairs, num_groups)
+            
+            # Expand back to original head structure
+            min_val = torch.repeat_interleave(min_val, COLLOCATED_HEADS, dim=0)
+            min_val = min_val.reshape(num_heads, num_groups).unsqueeze(0).unsqueeze(2)  # (1, num_heads, 1, num_groups)
+            min_val = torch.repeat_interleave(min_val, GROUP_SIZE, dim=3)  # (1, num_heads, 1, feature_dim)
+            
+            max_val = torch.repeat_interleave(max_val, COLLOCATED_HEADS, dim=0)
+            max_val = max_val.reshape(num_heads, num_groups).unsqueeze(0).unsqueeze(2)  # (1, num_heads, 1, num_groups)
+            max_val = torch.repeat_interleave(max_val, GROUP_SIZE, dim=3)  # (1, num_heads, 1, feature_dim)
         else:
             min_val = torch.amin(observed, dim=reduce_dims, keepdims=True)
             max_val = torch.amax(observed, dim=reduce_dims, keepdims=True)

--- a/src/llmcompressor/observers/min_max.py
+++ b/src/llmcompressor/observers/min_max.py
@@ -30,6 +30,7 @@ class MinMaxObserver(Observer):
         self.min_val = {}
         self.max_val = {}
         self.averaging_constant = averaging_constant
+        print(f"quantization_args: {self.quantization_args}")
 
     def calculate_qparams(
         self,
@@ -66,13 +67,16 @@ class MinMaxObserver(Observer):
             #quantization_args.strategy = QuantizationStrategy.CHANNEL
 
             # TODO: quantize part from few heads together (not from one head)
-            min_val = torch.amin(reshaped, dim=-1, keepdims=False).unsqueeze(0).unsqueeze(2)
+            min_val = torch.amin(reshaped, dim=-1, keepdims=False).unsqueeze(0).unsqueeze(2) #688 651 924
             min_val = torch.repeat_interleave(min_val, GROUP_SIZE, dim=3)
             max_val = torch.amax(reshaped, dim=-1, keepdims=False).unsqueeze(0).unsqueeze(2)
             max_val = torch.repeat_interleave(max_val, GROUP_SIZE, dim=3)
         else:
             min_val = torch.amin(observed, dim=reduce_dims, keepdims=True)
             max_val = torch.amax(observed, dim=reduce_dims, keepdims=True)
+
+        # print(f"min_val: {min_val}")
+        # print(f"max_val: {max_val}")
 
         # early stopping, save some computation and memory
         if self.averaging_constant == 1.0:
@@ -100,12 +104,14 @@ class MinMaxObserver(Observer):
         self.min_val[tensor_id] = updated_min_val
         self.max_val[tensor_id] = updated_max_val
 
-        return calculate_qparams(
+        qparams = calculate_qparams(
             min_vals=updated_min_val,
             max_vals=updated_max_val,
             quantization_args=self.quantization_args,
             global_scale=global_scale,
         )
+        #print(f"qparams: {qparams}")
+        return qparams
 
     def get_qparams_along_dim(
         self,


### PR DESCRIPTION
Implemented a static INT8 KV-cache where the scaling factor is shared across the entire sequence length and some portion of the hidden_dim (group size).